### PR TITLE
添加 LongCat-Flash-Omni 与 Ling-3.0-flash-VL 模型

### DIFF
--- a/src/data/models/index.js
+++ b/src/data/models/index.js
@@ -1,6 +1,8 @@
 // src/data/models/index.js
 // Models sorted by release date, newest first
 
+import longcat_flash_omni from './longcat_flash_omni/index.js'
+import ling3_flash_vl from './ling3_flash_vl/index.js'
 import glm5_3 from './glm5_3/index.js'
 import glm5_3_flash from './glm5_3_flash/index.js'
 import muse_glimmer_30b from './muse_glimmer_30b/index.js'
@@ -727,6 +729,8 @@ export const DENSE_MODELS = [
 
 export const MOE_MODELS = [
   // 2026
+  longcat_flash_omni,
+  ling3_flash_vl,
   glm5_3,
   glm5_3_flash,
   deepseek_v4_flash_vision_exp,

--- a/src/data/models/ling3_flash_vl/index.js
+++ b/src/data/models/ling3_flash_vl/index.js
@@ -1,11 +1,13 @@
 // Ling-3.0-flash-VL: 124B-A5.5B MoE (百灵 BailingMoeV3-VL), KDA linear + Gated MLA 混合, 原生多模态 VLM
 // 42 层混合架构（KDA 线性与 Gated MLA 按 5:1 交替）：35 KDA 线性层不占标准 KV + 7 MLA 全注意力层
-// 512 routed experts top-8 + 1 shared；前 2 层 dense 其余 MoE；ViT 沿用 qwen3_moe_vit（depth=27, hidden=1152）
+// 512 routed experts top-8 + 1 shared；前 2 层 dense 其余 MoE
 // Open weights: 2026-09 (HF + ModelScope, BF16/FP8)
 // Source: https://huggingface.co/inclusionAI/Ling-3.0-flash-VL/blob/main/config.json
 // Config: text_config num_hidden_layers=42, hidden_size=2560, num_attention_heads=32,
 //         num_key_value_heads=32, kv_lora_rank=512, qk_rope_head_dim=64, num_experts=512,
 //         num_experts_per_tok=8, layer_group_size=6, max_position_embeddings=131072（官方宣称 256K，可扩展）
+// Vision (qwen3_moe_vit): depth=27, hidden=1152, intermediate=4304, patch=16, spatial_merge=2,
+//         num_position_embeddings=2304 → 编码器约 0.4B，每图最大 2304/2² ≈ 576 视觉 token
 export default {
   id: 'ling3_flash_vl',
   name: 'Ling-3.0-flash-VL (124B-A5.5B)',
@@ -26,9 +28,9 @@ export default {
   head_dim: 128,
   hidden_size: 2560,
   max_ctx: 131072,
-  // ViT: qwen3_moe_vit depth=27, hidden=1152, patch=16, spatial_merge=2, out_hidden=4096
-  vision_encoder_params: 0.8,
-  vision_seq_tokens: 1280,
+  // ViT: qwen3_moe_vit depth=27 hidden=1152 ≈ 0.4B；spatial_merge=2 → 每图最大约 576 视觉 token
+  vision_encoder_params: 0.4,
+  vision_seq_tokens: 576,
   tags: ['chat', 'multilingual', 'coding', 'reasoning', 'vision', 'multimodal', 'agentic'],
   released: '2026-09',
   links: {

--- a/src/data/models/ling3_flash_vl/index.js
+++ b/src/data/models/ling3_flash_vl/index.js
@@ -1,0 +1,38 @@
+// Ling-3.0-flash-VL: 124B-A5.5B MoE (百灵 BailingMoeV3-VL), KDA linear + Gated MLA 混合, 原生多模态 VLM
+// 42 层混合架构（KDA 线性与 Gated MLA 按 5:1 交替）：35 KDA 线性层不占标准 KV + 7 MLA 全注意力层
+// 512 routed experts top-8 + 1 shared；前 2 层 dense 其余 MoE；ViT 沿用 qwen3_moe_vit（depth=27, hidden=1152）
+// Open weights: 2026-09 (HF + ModelScope, BF16/FP8)
+// Source: https://huggingface.co/inclusionAI/Ling-3.0-flash-VL/blob/main/config.json
+// Config: text_config num_hidden_layers=42, hidden_size=2560, num_attention_heads=32,
+//         num_key_value_heads=32, kv_lora_rank=512, qk_rope_head_dim=64, num_experts=512,
+//         num_experts_per_tok=8, layer_group_size=6, max_position_embeddings=131072（官方宣称 256K，可扩展）
+export default {
+  id: 'ling3_flash_vl',
+  name: 'Ling-3.0-flash-VL (124B-A5.5B)',
+  type: 'moe',
+  params: 124,
+  active_params: 5.5,
+  experts: 512,
+  experts_per_token: 8,
+  moe_execution: 'shared_routed',
+  layers: 42,
+  linear_attention_layers: 35, // KDA 线性层，不计标准 KV cache
+  local_layers: 35,
+  sliding_window: 0,
+  // 7 层 Gated MLA：每 token 每层缓存 kv_lora_rank(512) + qk_rope_head_dim(64) = 576，基线 2 × 32 × 128 = 8192
+  mla_ratio: 0.0703,  // 576 / 8192
+  query_heads: 32,     // num_attention_heads；hidden/head_dim 推不出（2560/128=20）
+  kv_heads: 32,
+  head_dim: 128,
+  hidden_size: 2560,
+  max_ctx: 131072,
+  // ViT: qwen3_moe_vit depth=27, hidden=1152, patch=16, spatial_merge=2, out_hidden=4096
+  vision_encoder_params: 0.8,
+  vision_seq_tokens: 1280,
+  tags: ['chat', 'multilingual', 'coding', 'reasoning', 'vision', 'multimodal', 'agentic'],
+  released: '2026-09',
+  links: {
+    hf: 'https://huggingface.co/inclusionAI/Ling-3.0-flash-VL',
+    ms: 'https://modelscope.cn/models/inclusionAI/Ling-3.0-flash-VL',
+  },
+}

--- a/src/data/models/longcat_flash_omni/index.js
+++ b/src/data/models/longcat_flash_omni/index.js
@@ -1,9 +1,12 @@
 // LongCat-Flash-Omni: 560B ScMoE / 27B active, MLA attention, zero-computation experts, omni-modal (text/image/video/audio)
-// Shortcut-connected MoE (dense FFN 并行 routed experts) + 256 zero-computation(identity) experts；轻量视觉/音频编码器各约 0.6B
+// Shortcut-connected MoE (dense FFN 并行 routed experts) + 256 zero-computation(identity) experts
+// 560B 为 LLM 主干（同 LongCat-Flash）；视觉/音频编码器为额外模块，本计算器仅建模视觉（音频无对应路径）
 // Open weights: 2026-09 (HF + ModelScope, MIT)
 // Source: https://huggingface.co/meituan-longcat/LongCat-Flash-Omni/blob/main/config.json
 // Config: num_layers=28, hidden_size=6144, num_attention_heads=64, attention_method=MLA,
 //         kv_lora_rank=512, qk_rope_head_dim=64, n_routed_experts=512, moe_topk=12, zero_expert_num=256
+// Vision (vision/config.json): num_hidden_layers=32, hidden_size=1280, intermediate=5184 (SwiGLU),
+//         patch=14, spatial_merge=1, image_size=1792, max_tokens=5832/图 → 编码器约 0.85B
 export default {
   id: 'longcat_flash_omni',
   name: 'LongCat-Flash-Omni (560B-A27B)',
@@ -21,8 +24,9 @@ export default {
   head_dim: 512,         // latent KV 维度（kv_lora_rank）
   hidden_size: 6144,
   max_ctx: 131072,
-  // 视觉编码器约 0.6B（官方 LLM config 未含多模态几何；音频模态本计算器不建模）
-  vision_encoder_params: 0.6,
+  // 视觉编码器 32 层 hidden=1280 SwiGLU ≈ 0.85B（额外于 560B 主干）；音频模态本计算器不建模
+  vision_encoder_params: 0.85,
+  vision_seq_tokens: 5832,  // max_tokens per image in vision/config.json（spatial_merge=1）
   tags: ['chat', 'multilingual', 'reasoning', 'vision', 'audio', 'multimodal'],
   released: '2026-09',
   links: {

--- a/src/data/models/longcat_flash_omni/index.js
+++ b/src/data/models/longcat_flash_omni/index.js
@@ -1,0 +1,32 @@
+// LongCat-Flash-Omni: 560B ScMoE / 27B active, MLA attention, zero-computation experts, omni-modal (text/image/video/audio)
+// Shortcut-connected MoE (dense FFN 并行 routed experts) + 256 zero-computation(identity) experts；轻量视觉/音频编码器各约 0.6B
+// Open weights: 2026-09 (HF + ModelScope, MIT)
+// Source: https://huggingface.co/meituan-longcat/LongCat-Flash-Omni/blob/main/config.json
+// Config: num_layers=28, hidden_size=6144, num_attention_heads=64, attention_method=MLA,
+//         kv_lora_rank=512, qk_rope_head_dim=64, n_routed_experts=512, moe_topk=12, zero_expert_num=256
+export default {
+  id: 'longcat_flash_omni',
+  name: 'LongCat-Flash-Omni (560B-A27B)',
+  type: 'moe',
+  params: 560,
+  active_params: 27,
+  experts: 512,
+  experts_per_token: 12,
+  moe_execution: 'parallel_dense_routed', // ScMoE：dense FFN(12288) 与 routed experts 并行
+  // MLA：每 token 每层缓存 kv_lora_rank(512) + qk_rope_head_dim(64) = 576，基线按 2 × 1 × 512 = 1024
+  mla_ratio: 0.5625,  // 576 / 1024
+  layers: 28,
+  query_heads: 64,       // num_attention_heads；hidden/head_dim 推不出（6144/512=12）
+  kv_heads: 1,
+  head_dim: 512,         // latent KV 维度（kv_lora_rank）
+  hidden_size: 6144,
+  max_ctx: 131072,
+  // 视觉编码器约 0.6B（官方 LLM config 未含多模态几何；音频模态本计算器不建模）
+  vision_encoder_params: 0.6,
+  tags: ['chat', 'multilingual', 'reasoning', 'vision', 'audio', 'multimodal'],
+  released: '2026-09',
+  links: {
+    hf: 'https://huggingface.co/meituan-longcat/LongCat-Flash-Omni',
+    ms: 'https://modelscope.cn/models/meituan-longcat/LongCat-Flash-Omni',
+  },
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

补录 2026-09 两家大厂新开源的 MoE 模型到计算器模型库（对照最近热度与部署门槛，这两个是最值得先收录的）：

- **LongCat-Flash-Omni（美团，560B-A27B）**：ScMoE + zero-computation experts，MLA 注意力，全模态（文/图/视频/音频），MIT。话题热度高、部署门槛也高，正好适合本计算器估算「要几张卡才跑得动」。
- **Ling-3.0-flash-VL（蚂蚁百灵，124B-A5.5B）**：KDA 线性 + Gated MLA 按 5:1 混合，原生多模态 VLM。体量小、下载量高，用户查询概率大。

## 改动

- 新增 `src/data/models/longcat_flash_omni/index.js`
- 新增 `src/data/models/ling3_flash_vl/index.js`
- `src/data/models/index.js`：按「发布日期倒序」在顶部注册两个模型（imports + `MOE_MODELS` 数组 2026 段）

字段口径严格对照现有同类条目：
- MLA 压缩沿用 `mla_ratio = (kv_lora_rank + qk_rope_head_dim) / (2 × kv_heads × head_dim)`（同 `glm5_3` / `deepseek_v4_pro`）
- KDA 线性层用 `linear_attention_layers` + `local_layers`/`sliding_window:0`（同 `glm5_3_flash` / `qwen38_flash_next`）
- MLA 升维用 `query_heads` 显式声明（同 `deepseek_v4_flash_vision_exp`）
- ScMoE 的 dense FFN 并行 routed 用 `moe_execution: 'parallel_dense_routed'`（同 `gemma4_26b_moe`）
- 视觉编码器字段按**各模型自身** `vision config` 估算，不借用别家条目的近似值
- 所有字段均标注 config.json 来源；LF 换行；tags 全部为现网既有标签

## 定稿取舍

- **Ling-3.0-flash-VL 上下文取 131072**：官方宣称 256K，但 VL 的 `config.json` `max_position_embeddings=131072`。遵循现网「以 config.json 原生值为准」的惯例（同 `qwen38_flash_next` 取原生 262144 而非营销 1M），并在注释标注官方 256K/可扩展。
- **视觉字段按各自 vision config 精确化**：
  - LongCat 依独立 `vision/config.json`（ViT 32 层 / hidden 1280 / SwiGLU / image_size 1792 / max_tokens 5832）→ `vision_encoder_params≈0.85`、`vision_seq_tokens=5832`
  - Ling 依其 `qwen3_moe_vit`（depth 27 / hidden 1152 / spatial_merge 2 / num_position_embeddings 2304）→ `vision_encoder_params≈0.4`、`vision_seq_tokens≈576`
- **音频模态不建模**：LongCat 为全模态，但本计算器只有文本+视觉路径，音频编码器未建模（注释已说明）。
- **HF / ModelScope 链接均已实测可达（HTTP 200）**，无死链。

## 数据来源

- LongCat-Flash-Omni：`meituan-longcat/LongCat-Flash-Omni` `config.json` + `vision/config.json`
- Ling-3.0-flash-VL：`inclusionAI/Ling-3.0-flash-VL` `config.json`（text_config + vision_config）

## 验证

- `npm run build` 通过（516 模块，PWA 生成正常）
- calc.js 冒烟（8×H200 FP8，含 `imageCount>0` 视觉路径）：两模型 VRAM/TPS 均为有限值，无 NaN/Inf；MoE 非专家参数为正；单流 decode 排序合理（Ling ≈39.5 > LongCat ≈31.6 tok/s）；视觉 token 计入正确（LongCat 5832×2、Ling 576×2）
- 浏览器端手测：模型选择器可搜到并选中两者，结果面板（VRAM/TPS/图表/量化对比表）正常刷新，控制台无 JS 报错

[new-models-longcat-ling-demo_small.mp4](https://cursor.com/agents/bc-840100cb-c91d-452b-a698-52340a198f38/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnew-models-longcat-ling-demo_small.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-840100cb-c91d-452b-a698-52340a198f38?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-840100cb-c91d-452b-a698-52340a198f38&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

