### PR TITLE
添加 Hy4 preview 模型并更新数据快照时间戳

### DIFF
--- a/public/llms.es.txt
+++ b/public/llms.es.txt
@@ -7,7 +7,7 @@ Código: https://github.com/adiudiuu/tps
 Otros idiomas: [简体中文](/llms.zh.txt) / [繁體中文](/llms.zh-TW.txt) / [English](/llms.txt) / [Русский](/llms.ru.txt) / [한국어](/llms.ko.txt) / [日本語](/llms.ja.txt)
 Interfaz: chino simplificado por defecto (sin query); `?lang=zh-TW` / `?lang=en` / `?lang=ru` / `?lang=es` / `?lang=ko` / `?lang=ja`
 
-Catálogo (conteos en vivo en Library): **405 modelos**, **251 GPUs**. Datos actualizados el **2026-09-01** (`UPDATED_AT_BEIJING`).
+Catálogo (conteos en vivo en Library): **405 modelos**, **251 GPUs**. Datos actualizados el **2026-09-10** (`UPDATED_AT_BEIJING`).
 
 ## Modelos populares en el catálogo
 

--- a/public/llms.ja.txt
+++ b/public/llms.ja.txt
@@ -7,7 +7,7 @@
 他言語: [简体中文](/llms.zh.txt) / [繁體中文](/llms.zh-TW.txt) / [English](/llms.txt) / [Русский](/llms.ru.txt) / [Español](/llms.es.txt) / [한국어](/llms.ko.txt)
 UI: 簡体中国語がデフォルト（クエリなし）；`?lang=zh-TW` / `?lang=en` / `?lang=ru` / `?lang=es` / `?lang=ko` / `?lang=ja`
 
-カタログ（Libraryのライブ件数）: **モデル405**、**GPU251**。データ更新 **2026-09-01**（`UPDATED_AT_BEIJING`）。
+カタログ（Libraryのライブ件数）: **モデル405**、**GPU251**。データ更新 **2026-09-10**（`UPDATED_AT_BEIJING`）。
 
 ## カタログの主要モデル
 

--- a/public/llms.ko.txt
+++ b/public/llms.ko.txt
@@ -7,7 +7,7 @@
 다른 언어: [简体中文](/llms.zh.txt) / [繁體中文](/llms.zh-TW.txt) / [English](/llms.txt) / [Русский](/llms.ru.txt) / [Español](/llms.es.txt) / [日本語](/llms.ja.txt)
 UI: 간체 중국어 기본(쿼리 없음); `?lang=zh-TW` / `?lang=en` / `?lang=ru` / `?lang=es` / `?lang=ko` / `?lang=ja`
 
-카탈로그(라이브러리 실시간 집계): **모델 405개**, **GPU 251개**. 데이터 갱신 **2026-09-01** (`UPDATED_AT_BEIJING`).
+카탈로그(라이브러리 실시간 집계): **모델 405개**, **GPU 251개**. 데이터 갱신 **2026-09-10** (`UPDATED_AT_BEIJING`).
 
 ## 카탈로그의 인기 모델
 

--- a/public/llms.ru.txt
+++ b/public/llms.ru.txt
@@ -7,7 +7,7 @@
 Другие языки: [简体中文](/llms.zh.txt) / [繁體中文](/llms.zh-TW.txt) / [English](/llms.txt) / [Español](/llms.es.txt) / [한국어](/llms.ko.txt) / [日本語](/llms.ja.txt)
 Интерфейс: упрощённый китайский по умолчанию (без query); `?lang=zh-TW` / `?lang=en` / `?lang=ru` / `?lang=es` / `?lang=ko` / `?lang=ja`
 
-Каталог (живые счётчики в Library): **405 модели**, **251 GPU**. Данные обновлены **2026-09-01** (`UPDATED_AT_BEIJING`).
+Каталог (живые счётчики в Library): **405 модели**, **251 GPU**. Данные обновлены **2026-09-10** (`UPDATED_AT_BEIJING`).
 
 ## Популярные модели в каталоге
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -6,7 +6,7 @@ Site: https://tps.bunai.com/
 Source: https://github.com/adiudiuu/tps
 Languages: English (this file) / [简体中文](/llms.zh.txt) / [繁體中文](/llms.zh-TW.txt) / [Русский](/llms.ru.txt) / [Español](/llms.es.txt) / [한국어](/llms.ko.txt) / [日本語](/llms.ja.txt). UI: Simplified Chinese default (no query); `?lang=zh-TW` / `?lang=en` / `?lang=ru` / `?lang=es` / `?lang=ko` / `?lang=ja`.
 
-Catalog (live counts in-app Library): **405 models**, **251 GPUs**. Data updated **2026-09-01** (`UPDATED_AT_BEIJING`).
+Catalog (live counts in-app Library): **405 models**, **251 GPUs**. Data updated **2026-09-10** (`UPDATED_AT_BEIJING`).
 
 ## Popular models you can estimate (in catalog)
 

--- a/public/llms.zh-TW.txt
+++ b/public/llms.zh-TW.txt
@@ -7,7 +7,7 @@
 其他語言：[簡體中文](/llms.zh.txt) / [English](/llms.txt) / [Русский](/llms.ru.txt) / [Español](/llms.es.txt) / [한국어](/llms.ko.txt) / [日本語](/llms.ja.txt)
 界面：簡體中文預設（不加 lang）；`?lang=zh-TW`（繁體中文）/ `?lang=en` / `?lang=ru` / `?lang=es` / `?lang=ko` / `?lang=ja`
 
-站內即時數量：**405 個模型**、**251 個 GPU**。資料更新至 **2026-09-01**（`UPDATED_AT_BEIJING`）。
+站內即時數量：**405 個模型**、**251 個 GPU**。資料更新至 **2026-09-10**（`UPDATED_AT_BEIJING`）。
 
 ## 可估計的熱門模型（均已入庫）
 

--- a/public/llms.zh.txt
+++ b/public/llms.zh.txt
@@ -7,7 +7,7 @@
 其他语言：[繁體中文](/llms.zh-TW.txt) / [English](/llms.txt) / [Русский](/llms.ru.txt) / [Español](/llms.es.txt) / [한국어](/llms.ko.txt) / [日本語](/llms.ja.txt)
 界面：简体中文默认（不加 lang）；`?lang=zh-TW`（繁體中文）/ `?lang=en` / `?lang=ru` / `?lang=es` / `?lang=ko` / `?lang=ja`
 
-站内实时数量：**405 个模型**、**251 个 GPU**。数据更新至 **2026-09-01**（`UPDATED_AT_BEIJING`）。
+站内实时数量：**405 个模型**、**251 个 GPU**。数据更新至 **2026-09-10**（`UPDATED_AT_BEIJING`）。
 
 ## 可估算的热门模型（均已入库）
 

--- a/src/data/appMeta.js
+++ b/src/data/appMeta.js
@@ -1,1 +1,1 @@
-export const UPDATED_AT_BEIJING = '2026/09/01 09:00'
+export const UPDATED_AT_BEIJING = '2026/09/10 13:09'

--- a/src/data/models/hy4/index.js
+++ b/src/data/models/hy4/index.js
@@ -1,0 +1,31 @@
+// Hy4 preview: 770B MoE / 49B active, Gated DSA (DeepSeek Sparse Attention) + IndexCache, 1M context
+// 78 层：第 1 层 dense FFN，其余 77 层 MoE；256 routed experts top-8 + 1 shared；原生 10B MTP 层供投机解码
+// Official preview from Tencent Hy Team, Apache 2.0, open weights 2026-08-28
+// Source: https://huggingface.co/tencent/Hy4-preview/blob/main/config.json
+// Config: num_hidden_layers=78, hidden_size=6144, num_attention_heads=64, num_key_value_heads=8,
+//         head_dim=64, gated_mla=true, kv_lora_rank=512, qk_rope_head_dim=64, q_lora_rank=2048,
+//         n_routed_experts=256, num_experts_per_tok=8, n_shared_experts=1, index_topk=2048
+export default {
+  id: 'hy4',
+  name: 'Hy4 preview (770B-A49B)',
+  type: 'moe',
+  params: 770,
+  active_params: 49,
+  experts: 256,
+  experts_per_token: 8,
+  moe_execution: 'shared_routed',
+  // Gated MLA：每 token 每层缓存 kv_lora_rank(512) + qk_rope_head_dim(64) = 576，基线 2 × 8 × 64 = 1024
+  mla_ratio: 0.5625,  // 576 / 1024
+  layers: 78,
+  query_heads: 64,     // num_attention_heads；hidden/head_dim 推不出（6144/64=96）
+  kv_heads: 8,
+  head_dim: 64,
+  hidden_size: 6144,
+  max_ctx: 1048576,
+  tags: ['chat', 'multilingual', 'reasoning', 'coding', 'agentic'],
+  released: '2026-08',
+  links: {
+    hf: 'https://huggingface.co/tencent/Hy4-preview',
+    ms: 'https://modelscope.cn/models/Tencent-Hunyuan/Hy4-preview',
+  },
+}

--- a/src/data/models/index.js
+++ b/src/data/models/index.js
@@ -3,6 +3,7 @@
 
 import longcat_flash_omni from './longcat_flash_omni/index.js'
 import ling3_flash_vl from './ling3_flash_vl/index.js'
+import hy4 from './hy4/index.js'
 import glm5_3 from './glm5_3/index.js'
 import glm5_3_flash from './glm5_3_flash/index.js'
 import muse_glimmer_30b from './muse_glimmer_30b/index.js'
@@ -731,6 +732,7 @@ export const MOE_MODELS = [
   // 2026
   longcat_flash_omni,
   ling3_flash_vl,
+  hy4,
   glm5_3,
   glm5_3_flash,
   deepseek_v4_flash_vision_exp,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

承接已合并的 [#4](https://github.com/adiudiuu/tps/pull/4)（已补录 LongCat-Flash-Omni、Ling-3.0-flash-VL）。本 PR 包含两件事：

1. **补录腾讯混元 Hy4 preview（770B-A49B）**（2026-08-28 开源，Apache 2.0）。至此美团 / 蚂蚁 / 腾讯 三家近期旗舰级开源模型齐备。
2. **更新数据快照时间戳** 至 `2026/09/10 13:09`（北京时间）。

## 改动

**新增模型**
- 新增 `src/data/models/hy4/index.js`
- `src/data/models/index.js`：在 `MOE_MODELS` 2026 段注册（imports + 数组）

Hy4 规格（`tencent/Hy4-preview` config.json，`model_type=hy_v4`）：770B-A49B MoE、78 层（第 1 层 dense、其余 77 层 MoE）、256 routed experts top-8 + 1 shared、hidden 6144、1M 上下文、Gated DSA（DeepSeek 稀疏注意力）+ IndexCache、原生 10B MTP 层。

字段口径对齐现网：Gated MLA `mla_ratio = (512 + 64) / (2 × 8 × 64) = 576/1024 = 0.5625`（同 `deepseek_v3_2` / `hy3`）；`query_heads: 64` 显式；`moe_execution: 'shared_routed'`。

**时间戳**
- `src/data/appMeta.js`：`UPDATED_AT_BEIJING` `2026/09/01 09:00` → `2026/09/10 13:09`（Header「更新于」单一真源，前端按浏览器本地时区渲染）
- `public/llms*.txt`（7 个语言）：同步硬编码日期 `2026-09-01` → `2026-09-10`，保持与真源一致
- SEO 月份粒度（`2026-09`）不变

## 验证

- `npm run build` 通过；改动文件全 LF；无残留旧日期
- Hy4 calc.js 冒烟（8×H200 FP8 EP8）：weight≈118.8GB/卡、KV≈5.9GB、runnable、decode≈21 tok/s、`attn=GQA (64/8)`，无 NaN/Inf
- 浏览器手测（Hy4）：可搜到并选中 “Hy4 preview (770B-A49B)”，显示 770B/49B/1M，结果面板正常刷新，控制台无 JS 报错
- 浏览器手测（时间戳）：Header 显示 `Updated 2026/09/10 05:09 UTC`（北京 13:09 → 本机 UTC 换算正确，日期已更新为 09-10）

[Header 显示 Updated 2026/09/10 05:09 UTC](https://cursor.com/agents/bc-840100cb-c91d-452b-a698-52340a198f38/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fupdated-timestamp-header.webp)

[hy4-model-demo_small.mp4](https://cursor.com/agents/bc-840100cb-c91d-452b-a698-52340a198f38/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhy4-model-demo_small.mp4)

### 备注（既有行为，非本 PR 引入）
手测发现切到 **LMDeploy** 且当前 GPU「Not supported」时速度/延迟栏显示 NaN。经核实为**全局既有 UI 行为**：calc 层对 Hy4 与既有模型（如 `glm5_3`）在 LMDeploy 下都返回正常有限值，NaN 来自 UI 对「框架-GPU 不支持」分支的展示，与本次改动无关。


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-840100cb-c91d-452b-a698-52340a198f38?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-840100cb-c91d-452b-a698-52340a198f38&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

