### PR TITLE
AGENTS.md 增补 Cursor Cloud 前端端到端验证约定

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,3 +91,13 @@ GatedDeltaNet / KDA 等不占标准 KV 的层，用 `linear_attention_layers` �
 - 任何改动后至少确保 `npm run build` 通过。
 - UI 改动要在浏览器实测（`npm run dev`，`5173`）。
 - 与 `calc.js` / `model.js` 相关的改动做 node 冒烟（见 3.11），确认结果为有限值。
+
+## Cursor Cloud specific instructions
+
+本仓库**无 lint、无自动化测试脚本**，前端 UI 改动一律需做端到端验证：
+
+- 环境：Node 先 `nvm use 22.16.0`；dev server 在 tmux 会话 `vite-dev-server` 跑于 `http://localhost:5173`（Vite HMR）。
+- 首选 **computerUse** 做真机点击 + 录屏 demo（当执行环境可用时）。
+- 当环境**无 computerUse**（如某些子代理）时，用 **headless Chrome + Chrome DevTools Protocol (CDP)** 驱动本地 dev server 的真实渲染页面验证：加载 `useUrlState` 产出的可分享 URL、真实点击按钮、劫持并读取 `window.open` 的目标（如 X intent URL）、读取 `canvas.toBlob` 产物的类型/尺寸、走能力检测分支（如 `navigator.share` / `ClipboardItem`）。
+- 无论哪种方式，都要**截图 / 存样本到 `/opt/cursor/artifacts/`** 作为证据。
+- 分享 / SEO 注意：X/Twitter、OG 等社交爬虫**抓取时不执行 JS**，SPA 运行时改 `<meta>` 对社交预览无效；需要 per-链接专属预览图，必须走构建期静态图或 serverless / 边缘生成。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

把前几次分享功能开发中沉淀的「前端端到端验证方式」固化进 `AGENTS.md`，方便后续统一维护。

## 改动

- `AGENTS.md`：在「验证与测试约定」之后新增一节 `## Cursor Cloud specific instructions`（保留该标准未编号标题，确保 Cursor Cloud Agent 可识别），约 10 行，LF：
  - 本仓库无 lint/无自动化测试，UI 改动需端到端验证
  - 环境要点：`nvm use 22.16.0`；dev server 在 tmux `vite-dev-server` @ `localhost:5173`
  - 首选 computerUse 真机点击 + 录屏 demo
  - 无 computerUse 时用 headless Chrome + CDP 驱动真实页面验证（可分享 URL、点击、劫持 `window.open`、`canvas.toBlob`、`navigator.share`/`ClipboardItem` 能力检测），证据存 `/opt/cursor/artifacts/`
  - 约束：社交/OG 爬虫不执行 JS，SPA 运行时改 `<meta>` 对预览无效；per-链接专属预览图需构建期静态图或 serverless/边缘生成

纯文档改动，无需 build/UI 测试。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-840100cb-c91d-452b-a698-52340a198f38?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-840100cb-c91d-452b-a698-52340a198f38&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

