### PR TITLE
修复分享文案导致的 vue-i18n 编译报错（SyntaxError）

### DIFF
--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -88,7 +88,7 @@ export default {
     copy_image: 'Copy image',
     image_copied: 'Image copied',
     image_error: 'Generation failed',
-    share_summary: 'Estimated with TPS Calculator: {model} @ {gpu} {runnable} | single-req {toks} | VRAM {vram} | TTFT {ttft}',
+    share_summary: "Estimated with TPS Calculator: {model} {'@'} {gpu} {runnable} {'|'} single-req {toks} {'|'} VRAM {vram} {'|'} TTFT {ttft}",
     share_runnable_yes: '✅ Runnable',
     share_runnable_no: '❌ Not runnable',
     card_single: 'Single',

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -88,7 +88,7 @@ export default {
     copy_image: 'Copiar imagen',
     image_copied: 'Imagen copiada',
     image_error: 'Error al generar',
-    share_summary: 'Estimado con TPS Calculator: {model} @ {gpu} {runnable} | por solicitud {toks} | VRAM {vram} | TTFT {ttft}',
+    share_summary: "Estimado con TPS Calculator: {model} {'@'} {gpu} {runnable} {'|'} por solicitud {toks} {'|'} VRAM {vram} {'|'} TTFT {ttft}",
     share_runnable_yes: '✅ Ejecutable',
     share_runnable_no: '❌ No ejecutable',
     card_single: 'Individual',

--- a/src/i18n/ja.js
+++ b/src/i18n/ja.js
@@ -88,7 +88,7 @@ export default {
     copy_image: '画像をコピー',
     image_copied: '画像をコピーしました',
     image_error: '生成に失敗しました',
-    share_summary: 'TPS Calculator で試算：{model} @ {gpu} {runnable}｜単一リクエスト {toks}｜VRAM {vram}｜TTFT {ttft}',
+    share_summary: "TPS Calculator で試算：{model} {'@'} {gpu} {runnable}｜単一リクエスト {toks}｜VRAM {vram}｜TTFT {ttft}",
     share_runnable_yes: '✅ 実行可',
     share_runnable_no: '❌ 実行不可',
     card_single: '単一',

--- a/src/i18n/ko.js
+++ b/src/i18n/ko.js
@@ -88,7 +88,7 @@ export default {
     copy_image: '이미지 복사',
     image_copied: '이미지 복사됨',
     image_error: '생성 실패',
-    share_summary: 'TPS Calculator로 추정: {model} @ {gpu} {runnable} | 단일 요청 {toks} | VRAM {vram} | TTFT {ttft}',
+    share_summary: "TPS Calculator로 추정: {model} {'@'} {gpu} {runnable} {'|'} 단일 요청 {toks} {'|'} VRAM {vram} {'|'} TTFT {ttft}",
     share_runnable_yes: '✅ 실행 가능',
     share_runnable_no: '❌ 실행 불가',
     card_single: '단일',

--- a/src/i18n/ru.js
+++ b/src/i18n/ru.js
@@ -88,7 +88,7 @@ export default {
     copy_image: 'Копировать изображение',
     image_copied: 'Изображение скопировано',
     image_error: 'Ошибка генерации',
-    share_summary: 'Оценка в TPS Calculator: {model} @ {gpu} {runnable} | один запрос {toks} | VRAM {vram} | TTFT {ttft}',
+    share_summary: "Оценка в TPS Calculator: {model} {'@'} {gpu} {runnable} {'|'} один запрос {toks} {'|'} VRAM {vram} {'|'} TTFT {ttft}",
     share_runnable_yes: '✅ Запускается',
     share_runnable_no: '❌ Не запускается',
     card_single: 'Запрос',

--- a/src/i18n/zh-TW.js
+++ b/src/i18n/zh-TW.js
@@ -88,7 +88,7 @@ export default {
     copy_image: "複製分享圖",
     image_copied: "圖片已複製",
     image_error: "產生失敗",
-    share_summary: "用 TPS Calculator 估算：{model} @ {gpu} {runnable}｜單請求 {toks}｜顯存 {vram}｜TTFT {ttft}",
+    share_summary: "用 TPS Calculator 估算：{model} {'@'} {gpu} {runnable}｜單請求 {toks}｜顯存 {vram}｜TTFT {ttft}",
     share_runnable_yes: "✅ 跑得動",
     share_runnable_no: "❌ 跑不動",
     card_single: "單請求",

--- a/src/i18n/zh.js
+++ b/src/i18n/zh.js
@@ -88,7 +88,7 @@ export default {
     copy_image: '复制分享图',
     image_copied: '图片已复制',
     image_error: '生成失败',
-    share_summary: '用 TPS Calculator 估算：{model} @ {gpu} {runnable}｜单请求 {toks}｜显存 {vram}｜TTFT {ttft}',
+    share_summary: "用 TPS Calculator 估算：{model} {'@'} {gpu} {runnable}｜单请求 {toks}｜显存 {vram}｜TTFT {ttft}",
     share_runnable_yes: '✅ 跑得动',
     share_runnable_no: '❌ 跑不动',
     card_single: '单请求',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

页面控制台报 `SyntaxError`，调用栈在 vue-vendor 的 **vue-i18n 消息编译器**（`nextToken`/`parse`）。已合并的分享功能（[#8](https://github.com/adiudiuu/tps/pull/8)）新增的 `nav.share_summary`（7 语言）里用了 vue-i18n 的**特殊字符字面量**：

- 半角 `@` —— vue-i18n 的 **linked-message** 语法（`@:key`）
- 半角 `|` —— vue-i18n 的**复数分隔符**（en/es/ko/ru）

该消息被 Header 的分享按钮 title / X 文案 computed 在渲染时求值 → vue-i18n 运行时编译 → 抛 `SyntaxError`，页面报错。（本项目 i18n 为运行时编译，`vite build` 不会捕获此类错误，故 #8 合并时未被发现。）

## 修复

对齐同文件既有正确写法（`nav.generated` 已用 `{'|'}` literal 转义）：
- `@` → `{'@'}`，半角 `|` → `{'|'}`（7 语言）
- 全角 `｜`（zh / zh-TW / ja 原本就用）保留，安全无需转义
- 外层字符串改双引号以容纳 `{'...'}`
- 渲染结果视觉不变（仍显示 `model @ gpu ｜ …`）

仅改 7 个 i18n 文件各 1 行，全 LF。

## 验证

- 用 `@intlify/message-compiler` **逐条编译全部 7 语言共 4277 条消息 → 0 失败**（修复前 `share_summary` 失败）
- `npm run build` 通过
- **浏览器复现验证**（computerUse）：加载报错 URL `?gpus=rtx4090:8&model=qwen38_27b&fw=vllm&pcie=gen4:1`，控制台**不再有 SyntaxError**；逐个切换 6 种语言（en/zh/ja/ko/es/ru）控制台均干净；打开分享菜单 / 分享到 X 正常，`@` 与 `|` 作为字面字符正确显示。

[加载报错 URL 后控制台无 SyntaxError](https://cursor.com/agents/bc-840100cb-c91d-452b-a698-52340a198f38/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fi18n-fix-console-1.webp)
[切换语言/分享后控制台无 SyntaxError](https://cursor.com/agents/bc-840100cb-c91d-452b-a698-52340a198f38/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fi18n-fix-console-2.webp)

> 注：验证录屏因录制进程异常未能保存，已用 computerUse 截图 + 编译扫描结果作为证据。


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-840100cb-c91d-452b-a698-52340a198f38?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-840100cb-c91d-452b-a698-52340a198f38&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

