### PR TITLE
BUN-9: 添加 DeepSeek-V4.1-Flash 并刷新数据快照时间戳

### DIFF
--- a/public/llms.es.txt
+++ b/public/llms.es.txt
@@ -7,7 +7,7 @@ Código: https://github.com/adiudiuu/tps
 Otros idiomas: [简体中文](/llms.zh.txt) / [繁體中文](/llms.zh-TW.txt) / [English](/llms.txt) / [Русский](/llms.ru.txt) / [한국어](/llms.ko.txt) / [日本語](/llms.ja.txt)
 Interfaz: chino simplificado por defecto (sin query); `?lang=zh-TW` / `?lang=en` / `?lang=ru` / `?lang=es` / `?lang=ko` / `?lang=ja`
 
-Catálogo (conteos en vivo en Library): **405 modelos**, **251 GPUs**. Datos actualizados el **2026-09-10** (`UPDATED_AT_BEIJING`).
+Catálogo (conteos en vivo en Library): **405 modelos**, **251 GPUs**. Datos actualizados el **2026-09-11** (`UPDATED_AT_BEIJING`).
 
 ## Modelos populares en el catálogo
 

--- a/public/llms.ja.txt
+++ b/public/llms.ja.txt
@@ -7,7 +7,7 @@
 他言語: [简体中文](/llms.zh.txt) / [繁體中文](/llms.zh-TW.txt) / [English](/llms.txt) / [Русский](/llms.ru.txt) / [Español](/llms.es.txt) / [한국어](/llms.ko.txt)
 UI: 簡体中国語がデフォルト（クエリなし）；`?lang=zh-TW` / `?lang=en` / `?lang=ru` / `?lang=es` / `?lang=ko` / `?lang=ja`
 
-カタログ（Libraryのライブ件数）: **モデル405**、**GPU251**。データ更新 **2026-09-10**（`UPDATED_AT_BEIJING`）。
+カタログ（Libraryのライブ件数）: **モデル405**、**GPU251**。データ更新 **2026-09-11**（`UPDATED_AT_BEIJING`）。
 
 ## カタログの主要モデル
 

--- a/public/llms.ko.txt
+++ b/public/llms.ko.txt
@@ -7,7 +7,7 @@
 다른 언어: [简体中文](/llms.zh.txt) / [繁體中文](/llms.zh-TW.txt) / [English](/llms.txt) / [Русский](/llms.ru.txt) / [Español](/llms.es.txt) / [日本語](/llms.ja.txt)
 UI: 간체 중국어 기본(쿼리 없음); `?lang=zh-TW` / `?lang=en` / `?lang=ru` / `?lang=es` / `?lang=ko` / `?lang=ja`
 
-카탈로그(라이브러리 실시간 집계): **모델 405개**, **GPU 251개**. 데이터 갱신 **2026-09-10** (`UPDATED_AT_BEIJING`).
+카탈로그(라이브러리 실시간 집계): **모델 405개**, **GPU 251개**. 데이터 갱신 **2026-09-11** (`UPDATED_AT_BEIJING`).
 
 ## 카탈로그의 인기 모델
 

--- a/public/llms.ru.txt
+++ b/public/llms.ru.txt
@@ -7,7 +7,7 @@
 Другие языки: [简体中文](/llms.zh.txt) / [繁體中文](/llms.zh-TW.txt) / [English](/llms.txt) / [Español](/llms.es.txt) / [한국어](/llms.ko.txt) / [日本語](/llms.ja.txt)
 Интерфейс: упрощённый китайский по умолчанию (без query); `?lang=zh-TW` / `?lang=en` / `?lang=ru` / `?lang=es` / `?lang=ko` / `?lang=ja`
 
-Каталог (живые счётчики в Library): **405 модели**, **251 GPU**. Данные обновлены **2026-09-10** (`UPDATED_AT_BEIJING`).
+Каталог (живые счётчики в Library): **405 модели**, **251 GPU**. Данные обновлены **2026-09-11** (`UPDATED_AT_BEIJING`).
 
 ## Популярные модели в каталоге
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -6,7 +6,7 @@ Site: https://tps.bunai.com/
 Source: https://github.com/adiudiuu/tps
 Languages: English (this file) / [简体中文](/llms.zh.txt) / [繁體中文](/llms.zh-TW.txt) / [Русский](/llms.ru.txt) / [Español](/llms.es.txt) / [한국어](/llms.ko.txt) / [日本語](/llms.ja.txt). UI: Simplified Chinese default (no query); `?lang=zh-TW` / `?lang=en` / `?lang=ru` / `?lang=es` / `?lang=ko` / `?lang=ja`.
 
-Catalog (live counts in-app Library): **405 models**, **251 GPUs**. Data updated **2026-09-10** (`UPDATED_AT_BEIJING`).
+Catalog (live counts in-app Library): **405 models**, **251 GPUs**. Data updated **2026-09-11** (`UPDATED_AT_BEIJING`).
 
 ## Popular models you can estimate (in catalog)
 

--- a/public/llms.zh-TW.txt
+++ b/public/llms.zh-TW.txt
@@ -7,7 +7,7 @@
 其他語言：[簡體中文](/llms.zh.txt) / [English](/llms.txt) / [Русский](/llms.ru.txt) / [Español](/llms.es.txt) / [한국어](/llms.ko.txt) / [日本語](/llms.ja.txt)
 界面：簡體中文預設（不加 lang）；`?lang=zh-TW`（繁體中文）/ `?lang=en` / `?lang=ru` / `?lang=es` / `?lang=ko` / `?lang=ja`
 
-站內即時數量：**405 個模型**、**251 個 GPU**。資料更新至 **2026-09-10**（`UPDATED_AT_BEIJING`）。
+站內即時數量：**405 個模型**、**251 個 GPU**。資料更新至 **2026-09-11**（`UPDATED_AT_BEIJING`）。
 
 ## 可估計的熱門模型（均已入庫）
 

--- a/public/llms.zh.txt
+++ b/public/llms.zh.txt
@@ -7,7 +7,7 @@
 其他语言：[繁體中文](/llms.zh-TW.txt) / [English](/llms.txt) / [Русский](/llms.ru.txt) / [Español](/llms.es.txt) / [한국어](/llms.ko.txt) / [日本語](/llms.ja.txt)
 界面：简体中文默认（不加 lang）；`?lang=zh-TW`（繁體中文）/ `?lang=en` / `?lang=ru` / `?lang=es` / `?lang=ko` / `?lang=ja`
 
-站内实时数量：**405 个模型**、**251 个 GPU**。数据更新至 **2026-09-10**（`UPDATED_AT_BEIJING`）。
+站内实时数量：**405 个模型**、**251 个 GPU**。数据更新至 **2026-09-11**（`UPDATED_AT_BEIJING`）。
 
 ## 可估算的热门模型（均已入库）
 

--- a/src/data/appMeta.js
+++ b/src/data/appMeta.js
@@ -1,1 +1,1 @@
-export const UPDATED_AT_BEIJING = '2026/09/10 13:09'
+export const UPDATED_AT_BEIJING = '2026/09/11 13:35'

--- a/src/data/models/deepseek_v4_1_flash/index.js
+++ b/src/data/models/deepseek_v4_1_flash/index.js
@@ -1,0 +1,41 @@
+// DeepSeek-V4.1-Flash: 552B MoE backbone / 8B prefill + 16B decode active, CED + CSA2, native VLM, 1M context
+// 40 层 Causal Encoder-Decoder（20 encoder + 20 decoder）；384 routed experts top-6 + 1 shared
+// 另有 Engram 条件记忆 196B（按 token 稀疏查表，不计入 backbone / params）
+// Official open weights: 2026-09-10, MIT
+// Source: https://huggingface.co/deepseek-ai/DeepSeek-V4.1-Flash/blob/main/config.json
+// text_config: num_hidden_layers=40, hidden_size=5120, num_attention_heads=64,
+//         num_key_value_heads=1, head_dim=512（latent KV）, qk_rope_head_dim=64,
+//         n_routed_experts=384, num_experts_per_tok=6, n_shared_experts=1,
+//         sliding_window=128, kv_source_layer_ids=[2,8,14,20], max_position_embeddings=1048576
+// Vision (vision_config): num_hidden_layers=32, hidden_size=1024, num_attention_heads=16,
+//         intermediate_size=2816, patch_size=14, downsample_ratio=3, max_image_tokens=1024
+export default {
+  id: 'deepseek_v4_1_flash',
+  name: 'DeepSeek V4.1 Flash (552B-A16B)',
+  type: 'moe',
+  params: 552,
+  active_params: 16, // 官方 8B prefill / 16B decode；TPS 按 decode
+  experts: 384,
+  experts_per_token: 6,
+  moe_execution: 'shared_routed',
+  // head_dim=512 即 latent KV 维度，实际缓存 512 + qk_rope_head_dim(64) = 576，基线为 2 × 1 × 512
+  mla_ratio: 0.5625,  // 576 / 1024
+  layers: 40,
+  query_heads: 64,       // num_attention_heads；hidden/head_dim 推不出（5120/512=10）
+  kv_heads: 1,
+  head_dim: 512,
+  hidden_size: 5120,
+  // 仅 4 层写全局 KV（kv_source_layer_ids）；其余层 SWA window=128
+  local_layers: 36,
+  sliding_window: 128,
+  max_ctx: 1048576,
+  // DeepSeek-ViT 32 层 hidden=1024 intermediate=2816 + 2 层 projector ≈ 0.4B（不在 552B backbone 内）
+  vision_encoder_params: 0.4,
+  vision_seq_tokens: 1024,  // max_image_tokens in vision_config
+  tags: ['chat', 'multilingual', 'coding', 'reasoning', 'vision', 'multimodal', 'agentic'],
+  released: '2026-09',
+  links: {
+    hf: 'https://huggingface.co/deepseek-ai/DeepSeek-V4.1-Flash',
+    ms: 'https://modelscope.cn/models/deepseek-ai/DeepSeek-V4.1-Flash',
+  },
+}

--- a/src/data/models/index.js
+++ b/src/data/models/index.js
@@ -122,6 +122,7 @@ import deepseek_v3_1 from './deepseek_v3_1/index.js'
 import deepseek_v3_2 from './deepseek_v3_2/index.js'
 import deepseek_v4_flash from './deepseek_v4_flash/index.js'
 import deepseek_v4_flash_vision_exp from './deepseek_v4_flash_vision_exp/index.js'
+import deepseek_v4_1_flash from './deepseek_v4_1_flash/index.js'
 import deepseek_v4_pro from './deepseek_v4_pro/index.js'
 import deepseek_janus_1_3b from './deepseek_janus_1_3b/index.js'
 import deepseek_janus_7b from './deepseek_janus_7b/index.js'
@@ -411,7 +412,7 @@ import llama_pro_8b from './llama_pro_8b/index.js'
 import llama2_chinese_13b from './llama2_chinese_13b/index.js'
 import linly_7b from './linly_7b/index.js'
 
-// Registered model counts: 405 unique (Dense 312 + MoE 93 by type)
+// Registered model counts: 406 unique (Dense 312 + MoE 94 by type)
 export const DENSE_MODELS = [
   // 2026
   muse_glimmer_30b,
@@ -730,6 +731,7 @@ export const DENSE_MODELS = [
 
 export const MOE_MODELS = [
   // 2026
+  deepseek_v4_1_flash,
   longcat_flash_omni,
   ling3_flash_vl,
   hy4,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

BUN-9 每日模型数据检查（同 BUN-5 SOP）。**有新模型**：补录 DeepSeek-V4.1-Flash；并刷新数据快照时间戳。

## 模型变更

新增 **DeepSeek V4.1 Flash (552B-A16B)**（`deepseek_v4_1_flash`）

- 实验室：DeepSeek，2026-09-10 开源，MIT
- 552B backbone MoE / decode 激活 16B（官方 prefill 8B / decode 16B），384 routed top-6 + 1 shared
- CED 40 层 + CSA2；`kv_source_layer_ids` 仅 4 层写全局 KV，其余 SWA 128
- 原生多模态；ViT 按自身 `vision_config` 估算约 0.4B，`max_image_tokens=1024`
- MLA 口径对齐现网 V4：`head_dim=512` latent KV，`mla_ratio=0.5625`，显式 `query_heads: 64`
- `max_ctx=1048576`（config 原生 `max_position_embeddings`）

来源：

- https://huggingface.co/deepseek-ai/DeepSeek-V4.1-Flash
- https://huggingface.co/deepseek-ai/DeepSeek-V4.1-Flash/blob/main/config.json
- https://modelscope.cn/models/deepseek-ai/DeepSeek-V4.1-Flash
- https://www.deepseek.com/news/deepseek-v4-1-flash/
- https://api-docs.deepseek.com/news/news260910

HF / ModelScope 均已 `curl -sI` 确认 HTTP 200。

其余大厂（Qwen / GLM / Kimi / MiniMax / Gemma / Llama / Hunyuan / LongCat / Ling 等）自 2026-09-10 快照以来无新的可收录开源权重或参数变更。

## 时间戳

- `UPDATED_AT_BEIJING`：`2026/09/10 13:09` → `2026/09/11 13:35`
- `public/llms*.txt`（7 个语言）：`2026-09-10` → `2026-09-11`

## 验证

- calcAll 冒烟（8×H200 FP8 EP8）：VRAM / TPS / TTFT 均为有限值，MoE 非专家参数约 7.5B > 0
- `npm run build`（Node 22.16.0）已通过

不合并到 main。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6dd32d93-c15d-5453-af45-ed9646f1a1e8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6dd32d93-c15d-5453-af45-ed9646f1a1e8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

